### PR TITLE
Don't print line number every time smoothie#middle() is called

### DIFF
--- a/autoload/smoothie.vim
+++ b/autoload/smoothie.vim
@@ -442,7 +442,6 @@ function smoothie#middle()
     exe "normal! zz"
     return
   endif
-  echom s:winmidline()
   let l:lines = s:calculate_screen_lines(s:winmidline(), line('.'))
   call s:perform_disjoint_scroll(l:lines)
 endfunction


### PR DESCRIPTION
I don't know why every time I pressed `zz` line number was displayed
Since it was a bit annoying I disabled it